### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Svenska Styrkelyftförbundet (SSF)
 
-Detta är SSFs GitHub repositorie. För tillfället kommer denna främst användas för SSFs databas och tillhörande webbsida.
+Detta är SSFs GitHub-repository. För tillfället kommer denna främst användas för SSFs databas och tillhörande webbsida.


### PR DESCRIPTION
En vanlig svensk översättning av "repository" är kort och gott "repo", så det kan vara ett alternativ. 

Men kanske det snarare är "SSFs GitHub-organisation" som avses, snarare än repo?